### PR TITLE
Fix the bug of ffi_c_crypto_binary package caused by c_check_exact_buffer_size macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@
 .idea/*
 *.iml
 *.tar.gz
-**/*.h
 

--- a/ffi/ffi_c/ffi_c_crypto_binary/Cargo.toml
+++ b/ffi/ffi_c/ffi_c_crypto_binary/Cargo.toml
@@ -30,7 +30,7 @@ libc = "0.2.60"
 protobuf = "2.22.1"
 wedpr_ffi_c_common = "1.0.0"
 wedpr_ffi_common = "1.1.0"
-wedpr_ffi_macros = "1.1.0"
+wedpr_ffi_macros = {path = "../../ffi_macros"}
 wedpr_l_crypto_block_cipher_aes = { path = "../../../crypto/block_cipher/aes", optional = true }
 wedpr_l_crypto_block_cipher_sm4 = { path = "../../../crypto/block_cipher/sm4", optional = true }
 wedpr_l_crypto_ecies_secp256k1 = { path = "../../../crypto/ecies/secp256k1", optional = true }

--- a/ffi/ffi_c/ffi_c_crypto_binary/src/signature.rs
+++ b/ffi/ffi_c/ffi_c_crypto_binary/src/signature.rs
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn wedpr_secp256k1_gen_key_pair(
     c_check_exact_buffer_size!(output_private_key, PRIVATE_KEY_SIZE);
 
     let (pk, sk) = SIGNATURE_SECP256K1.generate_keypair();
-    if output_public_key.len == PUBLIC_KEY_SIZE_WITH_PREFIX {
+    if output_public_key.len >= PUBLIC_KEY_SIZE_WITH_PREFIX {
         c_write_raw_pointer(&pk, output_public_key);
     } else {
         c_write_raw_pointer(
@@ -77,7 +77,14 @@ pub unsafe extern "C" fn wedpr_secp256k1_derive_public_key(
         Ok(v) => v,
         Err(_) => return FAILURE,
     };
-    c_write_raw_pointer(&pk, output_public_key);
+    if output_public_key.len >= PUBLIC_KEY_SIZE_WITH_PREFIX {
+        c_write_raw_pointer(&pk, output_public_key);
+    } else {
+        c_write_raw_pointer(
+            &pk[1..PUBLIC_KEY_SIZE_WITH_PREFIX],
+            output_public_key,
+        );
+    }
     SUCCESS
 }
 
@@ -153,7 +160,7 @@ pub unsafe extern "C" fn wedpr_secp256k1_recover_public_key(
         Ok(v) => v,
         Err(_) => return FAILURE,
     };
-    if output_public_key.len == PUBLIC_KEY_SIZE_WITH_PREFIX {
+    if output_public_key.len >= PUBLIC_KEY_SIZE_WITH_PREFIX {
         c_write_raw_pointer(&pk, output_public_key);
     } else {
         c_write_raw_pointer(
@@ -180,7 +187,7 @@ pub unsafe extern "C" fn wedpr_sm2_gen_key_pair(
     c_check_exact_buffer_size!(output_private_key, PRIVATE_KEY_SIZE);
 
     let (pk, sk) = SIGNATURE_SM2.generate_keypair();
-    if output_public_key.len == PUBLIC_KEY_SIZE_WITH_PREFIX {
+    if output_public_key.len >= PUBLIC_KEY_SIZE_WITH_PREFIX {
         c_write_raw_pointer(&pk, output_public_key);
     } else {
         c_write_raw_pointer(
@@ -211,7 +218,15 @@ pub unsafe extern "C" fn wedpr_sm2_derive_public_key(
         Ok(v) => v,
         Err(_) => return FAILURE,
     };
-    c_write_raw_pointer(&pk, output_public_key);
+    if output_public_key.len >= PUBLIC_KEY_SIZE_WITH_PREFIX {
+        c_write_raw_pointer(&pk, output_public_key);
+    } else {
+        c_write_raw_pointer(
+            &pk[1..PUBLIC_KEY_SIZE_WITH_PREFIX],
+            output_public_key,
+        );
+    }
+
     SUCCESS
 }
 
@@ -296,8 +311,13 @@ pub unsafe extern "C" fn wedpr_ed25519_gen_key_pair(
     output_public_key: &mut COutputBuffer,
     output_private_key: &mut COutputBuffer,
 ) -> i8 {
+    c_check_exact_buffer_size!(
+        output_public_key,
+        PUBLIC_KEY_SIZE_WITHOUT_PREFIX
+    );
+    c_check_exact_buffer_size!(output_private_key, PRIVATE_KEY_SIZE);
     let (pk, sk) = SIGNATURE_ED25519.generate_keypair();
-    if output_public_key.len == PUBLIC_KEY_SIZE_WITH_PREFIX {
+    if output_public_key.len >= PUBLIC_KEY_SIZE_WITH_PREFIX {
         c_write_raw_pointer(&pk, output_public_key);
     } else {
         c_write_raw_pointer(
@@ -316,6 +336,10 @@ pub unsafe extern "C" fn wedpr_ed25519_derive_public_key(
     raw_private_key: &CInputBuffer,
     output_public_key: &mut COutputBuffer,
 ) -> i8 {
+    c_check_exact_buffer_size!(
+        output_public_key,
+        PUBLIC_KEY_SIZE_WITHOUT_PREFIX
+    );
     let sk = c_read_raw_pointer(raw_private_key);
 
     let result = SIGNATURE_ED25519.derive_public_key(&sk);
@@ -324,7 +348,15 @@ pub unsafe extern "C" fn wedpr_ed25519_derive_public_key(
         Ok(v) => v,
         Err(_) => return FAILURE,
     };
-    c_write_raw_pointer(&pk, output_public_key);
+    if output_public_key.len >= PUBLIC_KEY_SIZE_WITH_PREFIX {
+        c_write_raw_pointer(&pk, output_public_key);
+    } else {
+        c_write_raw_pointer(
+            &pk[1..PUBLIC_KEY_SIZE_WITH_PREFIX],
+            output_public_key,
+        );
+    }
+
     SUCCESS
 }
 

--- a/ffi/ffi_macros/src/binary.rs
+++ b/ffi/ffi_macros/src/binary.rs
@@ -58,7 +58,7 @@ macro_rules! java_safe_bytes_to_jbyte_array {
 #[macro_export]
 macro_rules! c_check_exact_buffer_size {
     ($c_pointer:expr, $c_pointer_expected_length:expr) => {
-        if $c_pointer.len == $c_pointer_expected_length {
+        if $c_pointer.len < $c_pointer_expected_length {
             return FAILURE;
         }
     };

--- a/third_party/include/WeDPRBN128.h
+++ b/third_party/include/WeDPRBN128.h
@@ -1,0 +1,18 @@
+#ifndef _WEDPR_BN128_H_
+#define _WEDPR_BN128_H_
+#include "WeDPRUtilities.h"
+
+extern "C" {
+
+/// C interface for 'wedpr_fb_alt_bn128_g1_add'.
+int8_t wedpr_fb_alt_bn128_g1_add(const CInputBuffer* raw_pairing_data, COutputBuffer* output_point);
+
+/// C interface for 'wedpr_fb_alt_bn128_g1_mul'.
+int8_t wedpr_fb_alt_bn128_g1_mul(const CInputBuffer* raw_pairing_data, COutputBuffer* output_point);
+
+/// C interface for 'wedpr_fb_alt_bn128_pairing_product'.
+int8_t wedpr_fb_alt_bn128_pairing_product(
+    const CInputBuffer* raw_pairing_data, COutputBuffer* output_point);
+
+}  // extern "C"
+#endif

--- a/third_party/include/WeDPRCrypto.h
+++ b/third_party/include/WeDPRCrypto.h
@@ -1,0 +1,119 @@
+#ifndef _WEDPR_CRYPTO_H_
+#define _WEDPR_CRYPTO_H_
+#include "WeDPRUtilities.h"
+
+extern "C" {
+
+/// C interface for 'wedpr_aes256_encrypt'.
+int8_t wedpr_aes256_encrypt(const CInputBuffer* raw_plaintext, const CInputBuffer* raw_key,
+    const CInputBuffer* raw_iv, COutputBuffer* output_ciphertext);
+
+/// C interface for 'wedpr_aes256_decrypt'.
+int8_t wedpr_aes256_decrypt(const CInputBuffer* raw_ciphertext, const CInputBuffer* raw_key,
+    const CInputBuffer* raw_iv, COutputBuffer* output_plaintext);
+
+/// C interface for 'wedpr_sm4_encrypt'.
+int8_t wedpr_sm4_encrypt(const CInputBuffer* raw_plaintext, const CInputBuffer* raw_key,
+    const CInputBuffer* raw_iv, COutputBuffer* output_ciphertext);
+
+/// C interface for 'wedpr_sm4_decrypt'.
+int8_t wedpr_sm4_decrypt(const CInputBuffer* raw_ciphertext, const CInputBuffer* raw_key,
+    const CInputBuffer* raw_iv, COutputBuffer* output_plaintext);
+
+/// C interface for 'wedpr_keccak256_hash'.
+int8_t wedpr_keccak256_hash(const CInputBuffer* raw_message, COutputBuffer* output_hash);
+
+/// C interface for 'wedpr_sm3_hash'.
+int8_t wedpr_sm3_hash(const CInputBuffer* raw_message, COutputBuffer* output_hash);
+
+/// C interface for 'wedpr_ripemd160_hash'.
+int8_t wedpr_ripemd160_hash(const CInputBuffer* raw_message, COutputBuffer* output_hash);
+
+/// C interface for 'wedpr_sha3_hash'.
+int8_t wedpr_sha3_hash(const CInputBuffer* raw_message, COutputBuffer* output_hash);
+
+/// C interface for 'wedpr_blake2b_hash'.
+int8_t wedpr_blake2b_hash(const CInputBuffer* message_input, COutputBuffer* output_hash);
+
+/// C interface for 'wedpr_secp256k1_gen_key_pair'.
+int8_t wedpr_secp256k1_gen_key_pair(
+    COutputBuffer* output_public_key, COutputBuffer* output_private_key);
+
+/// C interface for 'wedpr_secp256k1_derive_public_key'.
+int8_t wedpr_secp256k1_derive_public_key(
+    const CInputBuffer* raw_private_key, COutputBuffer* output_public_key);
+
+/// C interface for 'wedpr_secp256k1_sign'.
+int8_t wedpr_secp256k1_sign(const CInputBuffer* raw_private_key,
+    const CInputBuffer* raw_message_hash, COutputBuffer* output_signature);
+
+/// C interface for 'wedpr_secp256k1_verify'.
+int8_t wedpr_secp256k1_verify(const CInputBuffer* raw_public_key,
+    const CInputBuffer* raw_message_hash, const CInputBuffer* raw_signature);
+
+/// C interface for 'wedpr_secp256k1_recover_public_key'.
+int8_t wedpr_secp256k1_recover_public_key(const CInputBuffer* raw_message_hash,
+    const CInputBuffer* raw_signature, COutputBuffer* output_public_key);
+
+/// C interface for 'wedpr_sm2_gen_key_pair'.
+int8_t wedpr_sm2_gen_key_pair(COutputBuffer* output_public_key, COutputBuffer* output_private_key);
+
+/// C interface for 'wedpr_sm2_derive_public_key'.
+int8_t wedpr_sm2_derive_public_key(
+    const CInputBuffer* raw_private_key, COutputBuffer* output_public_key);
+
+/// C interface for 'wedpr_sm2_sign'.
+int8_t wedpr_sm2_sign(const CInputBuffer* raw_private_key, const CInputBuffer* raw_message_hash,
+    COutputBuffer* output_signature);
+
+/// C interface for 'wedpr_sm2_sign_fast'.
+int8_t wedpr_sm2_sign_fast(const CInputBuffer* raw_private_key, const CInputBuffer* raw_public_key,
+    const CInputBuffer* raw_message_hash, COutputBuffer* output_signature);
+
+/// C interface for 'wedpr_sm2_verify'.
+int8_t wedpr_sm2_verify(const CInputBuffer* raw_public_key, const CInputBuffer* raw_message_hash,
+    const CInputBuffer* raw_signature);
+
+/// C interface for 'wedpr_ed25519_gen_key_pair'.
+int8_t wedpr_ed25519_gen_key_pair(
+    COutputBuffer* output_public_key, COutputBuffer* output_private_key);
+
+/// C interface for 'wedpr_ed25519_derive_public_key'.
+int8_t wedpr_ed25519_derive_public_key(
+    const CInputBuffer* raw_private_key, COutputBuffer* output_public_key);
+
+/// C interface for 'wedpr_ed25519_sign'.
+int8_t wedpr_ed25519_sign(const CInputBuffer* raw_private_key, const CInputBuffer* raw_message_hash,
+    COutputBuffer* output_signature);
+
+/// C interface for 'wedpr_ed25519_verify'.
+int8_t wedpr_ed25519_verify(const CInputBuffer* raw_public_key,
+    const CInputBuffer* raw_message_hash, const CInputBuffer* raw_signature);
+
+/// C interface for 'wedpr_curve25519_vrf_derive_public_key'.
+int8_t wedpr_curve25519_vrf_derive_public_key(
+    const CInputBuffer* raw_private_key, COutputBuffer* output_public_key);
+
+/// C interface for 'wedpr_curve25519_vrf_prove_utf8'.
+int8_t wedpr_curve25519_vrf_prove_utf8(const CInputBuffer* raw_private_key,
+    const CInputBuffer* raw_utf8_message, COutputBuffer* output_proof);
+
+/// C interface for 'wedpr_curve25519_vrf_prove_fast_utf8'.
+int8_t wedpr_curve25519_vrf_prove_fast_utf8(const CInputBuffer* raw_private_key,
+    const CInputBuffer* raw_public_key, const CInputBuffer* raw_utf8_message,
+    COutputBuffer* output_proof);
+
+/// C interface for 'wedpr_curve25519_vrf_verify_utf8'.
+int8_t wedpr_curve25519_vrf_verify_utf8(const CInputBuffer* raw_public_key,
+    const CInputBuffer* raw_utf8_message, const CInputBuffer* raw_proof);
+
+/// C interface for 'wedpr_curve25519_vrf_proof_to_hash'.
+int8_t wedpr_curve25519_vrf_proof_to_hash(
+    const CInputBuffer* raw_proof, COutputBuffer* output_hash);
+
+/// C interface for 'wedpr_curve25519_vrf_is_valid_public_key'.
+int8_t wedpr_curve25519_vrf_is_valid_public_key(const CInputBuffer* raw_public_key);
+
+}  // extern "C"
+
+#endif

--- a/third_party/include/WeDPRUtilities.h
+++ b/third_party/include/WeDPRUtilities.h
@@ -1,0 +1,20 @@
+#ifndef _WEDPR_UTILITIES_H_
+#define _WEDPR_UTILITIES_H_
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+#include <ostream>
+struct CInputBuffer
+{
+    const char* data;
+    uintptr_t len;
+};
+
+struct COutputBuffer
+{
+    char* data;
+    uintptr_t len;
+};
+#endif


### PR DESCRIPTION
1. add WeDPRCrypto and WeDPRBN128
2. Fix the bug of ffi_c_crypto_binary package caused by c_check_exact_buffer_size macro